### PR TITLE
Checks itemMetadata being 0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,10 @@ const initializeBot: Plugin = (bot, options) => {
     try {
       const itemMetadata = item.metadata[item.metadata.length - 1] as any;
       // In older versions blockId is used instead of itemId
+      if (itemMetadata === 0) {
+        // itemMetadata is 0, item no longer exists or is exp. Return
+        return
+      }
       var itemId =
         "itemId" in itemMetadata
           ? itemMetadata.itemId


### PR DESCRIPTION
Checks for a possibility of ItemMetaData being 0 before gives out an error of "Cannot use 'in' operator to search for 'itemId' in 0":
```js
Failed to retrieve block id, probably exp bottle TypeError: Cannot use 'in' operator to search for 'itemId' in 0
    at EventEmitter.onPlayerCollect ({ProjectPath}node_modules\mineflayer-armor-manager\dist\index.js:35:35)
    at EventEmitter.emit (node:events:388:22)
    at Client.<anonymous> ({ProjectPath}node_modules\mineflayer\lib\plugins\entities.js:160:9)
    at Client.emit (node:events:376:20)
    at FullPacketParser.<anonymous> ({ProjectPath}node_modules\minecraft-protocol\src\client.js:91:12)
    at FullPacketParser.emit (node:events:376:20)
    at addChunk ({ProjectPath}node_modules\readable-stream\lib\_stream_readable.js:298:12)
    at readableAddChunk ({ProjectPath}node_modules\readable-stream\lib\_stream_readable.js:280:11)
    at FullPacketParser.Readable.push ({ProjectPath}node_modules\readable-stream\lib\_stream_readable.js:241:10)
    at FullPacketParser.Transform.push ({ProjectPath}node_modules\readable-stream\lib\_stream_transform.js:139:32)
```
Does not throw an error as the item with a ItemMetaData being 0 would not equip-able regardless