### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "prismarine-windows": "^2.1.0",
     "typescript": "^4.0.2"
   },
-  "peerDependencies": {
-    "mineflayer": "^2.0.0"
-  },
   "dependencies": {
     "minecraft-data": "^2.65.0",
     "rambda": "^6.5.3"

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
   "dependencies": {
     "minecraft-data": "^2.65.0",
     "rambda": "^6.5.3"
-  }
+  },
+  "files": [
+    "dist/**/*"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,5 @@
   "dependencies": {
     "minecraft-data": "^2.65.0",
     "rambda": "^6.5.3"
-  },
-  "files": [
-    "dist/**/*"
-  ]
+  }
 }


### PR DESCRIPTION
fixes error when installing: 
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: thefratmaster-project@1.0.0
npm ERR! Found: mineflayer@3.7.0
npm ERR! node_modules/mineflayer
npm ERR!   mineflayer@"^3.7.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer mineflayer@"^2.0.0" from mineflayer-armor-manager@1.4.1
npm ERR! node_modules/mineflayer-armor-manager
npm ERR!   mineflayer-armor-manager@"https://github.com/PrismarineJS/MineflayerArmorManager" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See C:\Users\---\AppData\Local\npm-cache\eresolve-report.txt for a full report.
```